### PR TITLE
[Feat] 메인 퀴즈 기능 추가 및 pet 상태에 퀴즈 점수 반영 기능 추가

### DIFF
--- a/NewSerial/src/main/java/com/example/newserial/domain/member/service/MyPageService.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/member/service/MyPageService.java
@@ -92,7 +92,7 @@ public class MyPageService {
 
         if (!oxQuizAttemptList.isEmpty()){
             for(OxQuizAttempt oxQuizAttempt : oxQuizAttemptList){
-                OxQuiz oxQuiz=oxQuizAttempt.getOxQuiz();
+                OxQuiz oxQuiz=oxQuizRepository.findByWords(oxQuizAttempt.getWords()).get();
                 String quizQuestion=oxQuiz.getOxQuestion();
                 String quizAnswer=oxQuiz.getOxAnswer();
                 String userAnswer=oxQuizAttempt.getOxSubmitted();

--- a/NewSerial/src/main/java/com/example/newserial/domain/news/repository/News.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/news/repository/News.java
@@ -42,14 +42,4 @@ public class News {
     @OneToOne(cascade = CascadeType.ALL, mappedBy = "news")
     @PrimaryKeyJoinColumn
     private NewsQuiz newsQuiz;
-
-//    @OneToOne(mappedBy="news")
-//    private Bookmark bookmark;
-
-
-//    @OneToOne(mappedBy = "news")
-//    private News_quiz_attempt news_quiz_attempt;
-
-//    @OneToMany(mappedBy = "news") //cascade = CascadeType.REMOVE ?
-//    private List<Memo> memos; //이게 맞나
 }

--- a/NewSerial/src/main/java/com/example/newserial/domain/pet/repository/Pet.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/pet/repository/Pet.java
@@ -37,4 +37,11 @@ public class Pet {
     @JoinColumn(name="member_id")
     private Member member;
 
+    public void updateScore(int score){
+        this.score+=score;
+    }
+
+    public void updateCondition(PetCondition petCondition){
+        this.petCondition=petCondition;
+    }
 }

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/controller/QuizController.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/controller/QuizController.java
@@ -6,6 +6,7 @@ import com.example.newserial.domain.member.service.AuthDataService;
 import com.example.newserial.domain.news.service.NewsService;
 import com.example.newserial.domain.quiz.dto.NewsQuizAttemptRequestDto;
 import com.example.newserial.domain.quiz.dto.NewsQuizAttemptResponseDto;
+import com.example.newserial.domain.quiz.dto.OxQuizAttemptRequestDto;
 import com.example.newserial.domain.quiz.service.QuizService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -47,6 +48,30 @@ public class QuizController {
         try{
             Member member = authDataService.checkAccessToken(request);
             return ResponseEntity.ok(quizService.attemptNewsQuiz(member, newsQuizAttemptRequestDto));
+        } catch (BadRequestException e) {    //액세스 토큰, 리프레시 토큰 모두 만료된 경우
+            return authDataService.redirectToLogin();
+        }
+    }
+
+    //한입 퀴즈 저장 및 조회
+    @PostMapping("/main-quiz")
+    public ResponseEntity<?> getOXQuiz(HttpServletRequest request){
+        try {
+            Member member = authDataService.checkAccessToken(request);
+            return quizService.getOXQuiz(member);
+        } catch (BadRequestException e) {    //액세스 토큰, 리프레시 토큰 모두 만료된 경우
+            return authDataService.redirectToLogin();
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //한입 퀴즈 정답 제출
+    @PostMapping("/main-quiz/answer")
+    public ResponseEntity<?> attemptOXQuiz(@RequestBody OxQuizAttemptRequestDto oxQuizAttemptRequestDto, HttpServletRequest request){
+        try{
+            Member member = authDataService.checkAccessToken(request);
+            return ResponseEntity.ok(quizService.attemptOXQuiz(member, oxQuizAttemptRequestDto));
         } catch (BadRequestException e) {    //액세스 토큰, 리프레시 토큰 모두 만료된 경우
             return authDataService.redirectToLogin();
         }

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/dto/OxQuizAttemptRequestDto.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/dto/OxQuizAttemptRequestDto.java
@@ -1,0 +1,11 @@
+package com.example.newserial.domain.quiz.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OxQuizAttemptRequestDto {
+    private Long wordsId;
+    private String userAnswer;
+}

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/dto/OxQuizAttemptResponseDto.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/dto/OxQuizAttemptResponseDto.java
@@ -1,0 +1,24 @@
+package com.example.newserial.domain.quiz.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OxQuizAttemptResponseDto {//유저가 문제를 푼 경우 반환하는 dto
+    private Long wordsId;
+    private String question;
+    private String userAnswer;
+    private String quizAnswer;
+    private String result;
+    private String explanation;
+
+    public OxQuizAttemptResponseDto(Long wordsId, String question, String userAnswer, String quizAnswer, String result, String explanation) {
+        this.wordsId=wordsId;
+        this.question = question;
+        this.userAnswer = userAnswer;
+        this.quizAnswer = quizAnswer;
+        this.result = result;
+        this.explanation = explanation;
+    }
+}

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/dto/OxQuizNewsResponseDto.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/dto/OxQuizNewsResponseDto.java
@@ -1,10 +1,9 @@
 package com.example.newserial.domain.quiz.dto;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-public class MainQuizNewsResponseDto {
+public class OxQuizNewsResponseDto {
     private Long id;
     private String title;
 }

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/dto/OxQuizResponseDto.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/dto/OxQuizResponseDto.java
@@ -1,0 +1,16 @@
+package com.example.newserial.domain.quiz.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OxQuizResponseDto { // 유저가 문제를 풀지 않았을 경우 반환하는 dto
+    private Long wordsId;
+    private String question;
+
+    public OxQuizResponseDto(Long wordsId, String question) {
+        this.wordsId = wordsId;
+        this.question = question;
+    }
+}

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/NewsQuizAttemptRepository.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/NewsQuizAttemptRepository.java
@@ -1,6 +1,7 @@
 package com.example.newserial.domain.quiz.repository;
 
 import com.example.newserial.domain.member.repository.Member;
+import com.example.newserial.domain.news.repository.News;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +13,5 @@ public interface NewsQuizAttemptRepository extends JpaRepository<NewsQuizAttempt
 
     boolean existsByMember(Member member);
     List<NewsQuizAttempt> findByMember(Member member);
+    Optional<NewsQuizAttempt> findByMemberAndNews(Member member, News news);
 }

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuiz.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuiz.java
@@ -1,11 +1,10 @@
 package com.example.newserial.domain.quiz.repository;
 
 import com.example.newserial.domain.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import com.example.newserial.domain.news.repository.News;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,15 +22,28 @@ public class OxQuiz extends BaseTimeEntity {
      */
 
     @Id
-    @Column(name="ox_quiz_id")
-    private Long oxQuizId;
+    @Column(name="words_id")
+    private Long id;
 
     @Column(columnDefinition = "TEXT")
     private String oxQuestion;
 
-    @Column(length = 1)
+    @Column(columnDefinition = "TEXT")
     private String oxAnswer;
 
     @Column(columnDefinition = "TEXT")
     private String oxExplanation;
+
+    @Builder
+    public OxQuiz(Words words, String oxQuestion, String oxAnswer, String oxExplanation) {
+        this.words = words;
+        this.oxQuestion = oxQuestion;
+        this.oxAnswer = oxAnswer;
+        this.oxExplanation = oxExplanation;
+    }
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name="words_id")
+    private Words words;
 }

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuizAttempt.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuizAttempt.java
@@ -2,15 +2,9 @@ package com.example.newserial.domain.quiz.repository;
 
 import com.example.newserial.domain.BaseTimeEntity;
 import com.example.newserial.domain.member.repository.Member;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.IdClass;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,7 +12,6 @@ import lombok.NoArgsConstructor;
 @Table(name="ox_quiz_attempt")
 @Getter
 @NoArgsConstructor
-@AllArgsConstructor
 @IdClass(OxQuizAttemptId.class)
 public class OxQuizAttempt extends BaseTimeEntity {
     /**
@@ -29,17 +22,25 @@ public class OxQuizAttempt extends BaseTimeEntity {
      */
 
     @Id
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="member_id")
     private Member member;
 
     @Id
-    @OneToOne
-    @JoinColumn(name = "ox_quiz_id")
-    private OxQuiz oxQuiz;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "words_id")
+    private Words words;
 
     private int oxScore;
 
-    @Column(length = 1)
+    @Column(columnDefinition = "TEXT")
     private String oxSubmitted;
+
+    @Builder
+    public OxQuizAttempt(Member member, Words words, int oxScore, String oxSubmitted) {
+        this.member = member;
+        this.words = words;
+        this.oxScore = oxScore;
+        this.oxSubmitted = oxSubmitted;
+    }
 }

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuizAttemptId.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuizAttemptId.java
@@ -14,6 +14,6 @@ import java.util.Objects;
 public class OxQuizAttemptId implements Serializable {
     //     * PK: {member_id(FK)    bigint | OX_quiz_id(FK)    bigint}
     private Member member;
-    private OxQuiz oxQuiz;
+    private Words words;
 
 }

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuizAttemptRepository.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuizAttemptRepository.java
@@ -5,8 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface OxQuizAttemptRepository extends JpaRepository<OxQuizAttempt, OxQuizAttemptId> {
+    boolean existsByMember(Member member);
     List<OxQuizAttempt> findByMember(Member member);
+    Optional<OxQuizAttempt> findByMemberAndWords(Member member, Words words);
 }

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuizRepository.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuizRepository.java
@@ -3,6 +3,10 @@ package com.example.newserial.domain.quiz.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface OxQuizRepository extends JpaRepository<OxQuiz, Long> {
+    boolean existsByWords(Words words);
+    Optional<OxQuiz> findByWords(Words words);
 }

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/Words.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/Words.java
@@ -1,0 +1,22 @@
+package com.example.newserial.domain.quiz.repository;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name="words")
+public class Words {
+    @Id
+    private Long id;
+
+    private String word;
+
+    @OneToOne(cascade = CascadeType.ALL, mappedBy = "words")
+    @PrimaryKeyJoinColumn
+    private OxQuiz oxQuiz;
+}

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/WordsRepository.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/WordsRepository.java
@@ -1,0 +1,8 @@
+package com.example.newserial.domain.quiz.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WordsRepository extends JpaRepository<Words, Long> {
+}

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/service/QuizService.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/service/QuizService.java
@@ -6,11 +6,10 @@ import com.example.newserial.domain.news.dto.ChatGptMessage;
 import com.example.newserial.domain.news.dto.ChatGptRequestDto;
 import com.example.newserial.domain.news.dto.ChatGptResponseDto;
 import com.example.newserial.domain.pet.repository.Pet;
+import com.example.newserial.domain.pet.repository.PetCondition;
+import com.example.newserial.domain.pet.repository.PetConditionRepository;
 import com.example.newserial.domain.pet.repository.PetRepository;
-import com.example.newserial.domain.quiz.dto.MainQuizNewsResponseDto;
-import com.example.newserial.domain.quiz.dto.NewsQuizAttemptRequestDto;
-import com.example.newserial.domain.quiz.dto.NewsQuizAttemptResponseDto;
-import com.example.newserial.domain.quiz.dto.NewsQuizResponseDto;
+import com.example.newserial.domain.quiz.dto.*;
 import com.example.newserial.domain.news.repository.News;
 import com.example.newserial.domain.news.repository.NewsRepository;
 import com.example.newserial.domain.quiz.repository.*;
@@ -30,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+import java.io.BufferedOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -43,18 +43,25 @@ public class QuizService {
     private final NewsRepository newsRepository;
     private final NewsQuizRepository newsQuizRepository;
     private final NewsQuizAttemptRepository newsQuizAttemptRepository;
+    private final OxQuizRepository oxQuizRepository;
     private final OxQuizAttemptRepository oxQuizAttemptRepository;
     private final PetRepository petRepository;
+    private final WordsRepository wordsRepository;
+    private final PetConditionRepository petConditionRepository;
 
     @Autowired
     public QuizService(NewsRepository newsRepository, NewsQuizRepository newsQuizRepository,
                        NewsQuizAttemptRepository newsQuizAttemptRepository, OxQuizAttemptRepository oxQuizAttemptRepository,
-                       PetRepository petRepository){
+                       PetRepository petRepository, OxQuizRepository oxQuizRepository,
+                       WordsRepository wordsRepository, PetConditionRepository petConditionRepository){
         this.newsRepository=newsRepository;
         this.newsQuizRepository=newsQuizRepository;
         this.newsQuizAttemptRepository=newsQuizAttemptRepository;
+        this.oxQuizRepository=oxQuizRepository;
         this.oxQuizAttemptRepository=oxQuizAttemptRepository;
         this.petRepository=petRepository;
+        this.petConditionRepository=petConditionRepository;
+        this.wordsRepository=wordsRepository;
     }
 
 
@@ -83,8 +90,7 @@ public class QuizService {
         if (newsQuizAttemptRepository.existsByMember(member)) { //유저가 이미 퀴즈를 푼 경우
             if (newsQuizRepository.existsByNews(news)) {
                 NewsQuiz newsQuiz = newsQuizRepository.findByNews(news).get();
-                List<NewsQuizAttempt> newsQuizAttemptList = newsQuizAttemptRepository.findByMember(member);
-                NewsQuizAttempt newsQuizAttempt=newsQuizAttemptList.get(0);
+                NewsQuizAttempt newsQuizAttempt = newsQuizAttemptRepository.findByMemberAndNews(member, news).get();
                 String question = newsQuiz.getNews_question();
                 String userAnswer = newsQuizAttempt.getNews_submitted(); //사용자 정답
                 String qAnswer = newsQuiz.getNews_answer(); //뉴스 정답
@@ -187,7 +193,7 @@ public class QuizService {
         String explanation= newsQuiz.getNews_explanation();
 
         Pet pet=petRepository.findByMember(member).get();
-        int petScore=pet.getScore();
+        int petConditionId=pet.getPetCondition().getId(); //유저의 펫 랭크 id값
 
         if (userAnswer.equals(qAnswer)){ //사용자 정답이 맞는 경우: 2점
             NewsQuizAttempt newsQuizAttempt=NewsQuizAttempt.builder()
@@ -199,7 +205,14 @@ public class QuizService {
 
             newsQuizAttemptRepository.save(newsQuizAttempt);
 
-            petScore+=2;
+            pet.updateScore(2);
+            int petScore=pet.getScore();
+
+            if(petScore>=petConditionRepository.findById((long) (petConditionId+1)).get().getCount()){
+                petConditionId+=1;
+                PetCondition petCondition=petConditionRepository.findById((long) petConditionId).get();
+                pet.updateCondition(petCondition);
+            }
 
             NewsQuizAttemptResponseDto newsQuizAttemptResponseDto=new NewsQuizAttemptResponseDto(question, userAnswer,qAnswer,"맞았습니다", explanation);
             return newsQuizAttemptResponseDto;
@@ -214,10 +227,164 @@ public class QuizService {
 
             newsQuizAttemptRepository.save(newsQuizAttempt);
 
-            petScore+=1;
+            pet.updateScore(1);
+            int petScore=pet.getScore();
+
+            if(petScore>=petConditionRepository.findById((long) (petConditionId+1)).get().getCount()){
+                petConditionId+=1;
+                PetCondition petCondition=petConditionRepository.findById((long) petConditionId).get();
+                pet.updateCondition(petCondition);
+            }
 
             NewsQuizAttemptResponseDto newsQuizAttemptResponseDto=new NewsQuizAttemptResponseDto(question, userAnswer,qAnswer,"틀렸습니다", explanation);
             return newsQuizAttemptResponseDto;
+        }
+    }
+
+    //메인: 한입퀴즈 반환 메소드
+    @Transactional
+    public ResponseEntity<?> getOXQuiz(Member member) throws JsonProcessingException {
+
+        int randomVal=(int)(Math.random()*(715)-1)+1; //1~714
+
+        Words words=wordsRepository.findById((long) randomVal).get();
+
+        if (oxQuizAttemptRepository.existsByMember(member)) { //유저가 이미 퀴즈를 푼 경우
+            if (oxQuizRepository.existsByWords(words)) { //유저가 풀었으므로 당연히 db에 저장돼있는 퀴즈일 것
+                OxQuiz oxQuiz = oxQuizRepository.findByWords(words).get();
+                OxQuizAttempt oxQuizAttempt=oxQuizAttemptRepository.findByMemberAndWords(member, words).get();
+                String question = oxQuiz.getOxQuestion();
+                String userAnswer = oxQuizAttempt.getOxSubmitted(); //사용자 정답
+                String qAnswer = oxQuiz.getOxAnswer(); //뉴스 정답
+                String result = (userAnswer.equals(qAnswer)) ? "맞았습니다" : "틀렸습니다";
+                String explanation = oxQuiz.getOxExplanation();
+
+                OxQuizAttemptResponseDto oxQuizAttemptResponseDto = new OxQuizAttemptResponseDto(words.getId(), question, userAnswer, qAnswer, result, explanation);
+
+                return ResponseEntity.ok(oxQuizAttemptResponseDto);
+            }
+        } else { //유저가 아직 퀴즈를 풀지 않은 경우
+            if (oxQuizRepository.existsByWords(words)) { //뉴스에 대한 퀴즈가 이미 db에 저장돼있는 경우 db에서 가져와 반환
+                OxQuiz oxQuiz = oxQuizRepository.findByWords(words).get();
+                String question = oxQuiz.getOxQuestion();
+                OxQuizResponseDto oxQuizResponseDto = new OxQuizResponseDto(words.getId(), question);
+                return ResponseEntity.ok(oxQuizResponseDto);
+            } else { //뉴스에 대한 퀴즈가 db에 없는 경우 챗gpt에 요청을 보내고 새로 저장 후 반환
+                String word = words.getWord();
+                WebClient client = WebClient.builder()
+                        .baseUrl(ChatGptConfig.CHAT_URL)
+                        .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE) //defaultHeader: 모든 요청에 사용할 헤더
+                        .defaultHeader(ChatGptConfig.AUTHORIZATION, ChatGptConfig.BEARER + apiKey)
+                        .build();
+
+                String prompt = word + "\n" +
+                        "위 경제용어의 정의와 관련된 O/X 퀴즈를 만들어 '퀴즈:' 다음에 적어주세요. 예를 들어, '물가 상승률은 물가가 얼마나 상승했는지 나타내는 지표이다.' 이런 식으로 작성해주세요.\n" +
+                        "다음 줄에 그 퀴즈의 답이 O와 X 중 무엇인지 '답:' 다음에 적어주세요.\n" +
+                        "다음 줄에 그 퀴즈의 답에 대한 설명을 '설명:' 다음에 적어주세요.\n";
+
+                List<ChatGptMessage> messages = new ArrayList<>();
+                messages.add(ChatGptMessage.builder()
+                        .role(ChatGptConfig.ROLE)
+                        .content(prompt)
+                        .build());
+                ChatGptRequestDto chatGptRequest = new ChatGptRequestDto(
+                        ChatGptConfig.CHAT_MODEL,
+                        ChatGptConfig.MAX_TOKEN,
+                        ChatGptConfig.TEMPERATURE,
+                        ChatGptConfig.STREAM,
+                        messages
+                );
+                String requestValue = objectMapper.writeValueAsString(chatGptRequest);
+
+                Mono<ChatGptResponseDto> responseMono = client.post() //HTTP POST 요청 생성
+                        .bodyValue(requestValue) //POST 요청의 본문(body) 설정, ChatGpt 서비스로 전송할 데이터
+                        .accept(MediaType.APPLICATION_JSON)
+                        .retrieve()
+                        .bodyToMono(ChatGptResponseDto.class); // ChatGptResponseDto로 받기
+
+                ChatGptResponseDto chatGptResponseDto = responseMono.block();
+                String content = getContentFromResponse(chatGptResponseDto);
+
+//        System.out.println("content = " + content);
+
+                String quiz = extractContent(content, "퀴즈", "\\n");
+                String answer = extractContent(content, "답", "\\n");
+                String explanation = extractContent(content, "설명", null);
+
+                OxQuiz oxQuiz=OxQuiz.builder()
+                        .words(words)
+                        .oxQuestion(quiz)
+                        .oxAnswer(answer)
+                        .oxExplanation(explanation)
+                        .build();
+
+                oxQuizRepository.save(oxQuiz);
+
+                OxQuizResponseDto oxQuizResponseDto = new OxQuizResponseDto(words.getId(), quiz);
+
+                return ResponseEntity.ok(oxQuizResponseDto);
+            }
+        }
+        return null;
+    }
+
+    //메인: 한입 퀴즈 푸는 메소드
+    @Transactional
+    public OxQuizAttemptResponseDto attemptOXQuiz(Member member, OxQuizAttemptRequestDto oxQuizAttemptRequestDto){ //뉴스 id, 사용자 정답 제출
+        Words words=wordsRepository.findById(oxQuizAttemptRequestDto.getWordsId()).get();
+        OxQuiz oxQuiz=oxQuizRepository.findByWords(words).get();
+
+        String question=oxQuiz.getOxQuestion();
+        String userAnswer=oxQuizAttemptRequestDto.getUserAnswer(); //사용자 정답
+        String qAnswer=oxQuiz.getOxAnswer(); //뉴스 정답
+        String explanation=oxQuiz.getOxExplanation();
+
+        Pet pet=petRepository.findByMember(member).get();
+        int petConditionId=pet.getPetCondition().getId(); //유저의 펫 랭크 id값
+
+        if (userAnswer.equals(qAnswer)){ //사용자 정답이 맞는 경우: 2점
+            OxQuizAttempt oxQuizAttempt=OxQuizAttempt.builder()
+                    .member(member)
+                    .words(words)
+                    .oxScore(2)
+                    .oxSubmitted(userAnswer)
+                    .build();
+
+            oxQuizAttemptRepository.save(oxQuizAttempt);
+
+            pet.updateScore(2);
+            int petScore=pet.getScore();
+
+            if(petScore>=petConditionRepository.findById((long) (petConditionId+1)).get().getCount()){
+                petConditionId+=1;
+                PetCondition petCondition=petConditionRepository.findById((long) petConditionId).get();
+                pet.updateCondition(petCondition);
+            }
+
+            OxQuizAttemptResponseDto oxQuizAttemptResponseDto=new OxQuizAttemptResponseDto(words.getId(), question, userAnswer,qAnswer,"맞았습니다", explanation);
+            return oxQuizAttemptResponseDto;
+        }
+        else{ //사용자 정답이 틀린 경우: 1점
+            OxQuizAttempt oxQuizAttempt=OxQuizAttempt.builder()
+                    .member(member)
+                    .words(words)
+                    .oxScore(1)
+                    .oxSubmitted(userAnswer)
+                    .build();
+
+            oxQuizAttemptRepository.save(oxQuizAttempt);
+
+            pet.updateScore(1);
+            int petScore=pet.getScore();
+
+            if(petScore>=petConditionRepository.findById((long) (petConditionId+1)).get().getCount()){
+                petConditionId+=1;
+                PetCondition petCondition=petConditionRepository.findById((long) petConditionId).get();
+                pet.updateCondition(petCondition);
+            }
+
+            OxQuizAttemptResponseDto oxQuizAttemptResponseDto=new OxQuizAttemptResponseDto(words.getId(), question, userAnswer,qAnswer,"틀렸습니다", explanation);
+            return oxQuizAttemptResponseDto;
         }
     }
 


### PR DESCRIPTION
- 메인 퀴즈 조회 및 정답 제출 기능 추가
- 퀴즈를 풀고 얻은 점수를 사용자의 pet 엔티티에 업데이트하고, pet 상태도 업데이트하는 기능 추가.