### PR TITLE
[Fix] 한입퀴즈 수정 및 회원가입 시 펫 엔티티 추가

### DIFF
--- a/NewSerial/src/main/java/com/example/newserial/domain/member/config/oauth2/service/CustomOAuth2UserService.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/member/config/oauth2/service/CustomOAuth2UserService.java
@@ -11,6 +11,10 @@ import com.example.newserial.domain.member.repository.Member;
 import com.example.newserial.domain.member.repository.MemberRepository;
 import com.example.newserial.domain.member.repository.SocialMember;
 import com.example.newserial.domain.member.repository.SocialMemberRepository;
+import com.example.newserial.domain.pet.repository.Pet;
+import com.example.newserial.domain.pet.repository.PetCondition;
+import com.example.newserial.domain.pet.repository.PetConditionRepository;
+import com.example.newserial.domain.pet.repository.PetRepository;
 import jakarta.persistence.EntityManager;
 import java.util.Map;
 import java.util.Optional;
@@ -35,6 +39,8 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     private final MemberRepository memberRepository;
     private final SocialMemberRepository socialMemberRepository;
+    private final PetRepository petRepository;
+    private final PetConditionRepository petConditionRepository;
     private final EntityManager entityManager;
 
     private static final String NAVER = "naver";
@@ -111,6 +117,12 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         SocialMember socialMember = attributes.makeSocialMember(socialType, member);
         //member가 이미 db에 존재하기 때문에 오류생긴다 (엔티티 종속성 문제 발생..) 어떻게 해야할까..
         socialMemberRepository.save(socialMember);
+
+        //펫 엔티티 추가
+        PetCondition petCondition=petConditionRepository.findById(1L).get();
+        Pet pet=new Pet(petCondition,0,null,member);
+        petRepository.save(pet);
+
         return member;
     }
 }

--- a/NewSerial/src/main/java/com/example/newserial/domain/member/service/AuthService.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/member/service/AuthService.java
@@ -10,6 +10,10 @@ import com.example.newserial.domain.member.dto.request.LoginRequestDto;
 import com.example.newserial.domain.member.dto.request.SignupRequestDto;
 import com.example.newserial.domain.member.repository.Member;
 import com.example.newserial.domain.member.repository.MemberRepository;
+import com.example.newserial.domain.pet.repository.Pet;
+import com.example.newserial.domain.pet.repository.PetCondition;
+import com.example.newserial.domain.pet.repository.PetConditionRepository;
+import com.example.newserial.domain.pet.repository.PetRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -27,6 +31,8 @@ public class AuthService {
 
     private final AuthenticationManager authenticationManager;
     private final MemberRepository memberRepository;
+    private final PetRepository petRepository;
+    private final PetConditionRepository petConditionRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtils jwtUtils;
 
@@ -67,6 +73,11 @@ public class AuthService {
                 passwordEncoder.encode(request.getPassword()));
 
         memberRepository.save(member);
+
+        //펫 엔티티 추가
+        PetCondition petCondition=petConditionRepository.findById(1L).get();
+        Pet pet=new Pet(petCondition,0,null,member);
+        petRepository.save(pet);
     }
 
     public void changePassword(String email, String newPassword) {

--- a/NewSerial/src/main/java/com/example/newserial/domain/pet/repository/Pet.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/pet/repository/Pet.java
@@ -37,6 +37,13 @@ public class Pet {
     @JoinColumn(name="member_id")
     private Member member;
 
+    public Pet(PetCondition petCondition, int score, String petImage, Member member) {
+        this.petCondition = petCondition;
+        this.score = score;
+        this.petImage = petImage;
+        this.member = member;
+    }
+
     public void updateScore(int score){
         this.score+=score;
     }

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/controller/QuizController.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/controller/QuizController.java
@@ -3,19 +3,14 @@ package com.example.newserial.domain.quiz.controller;
 import com.example.newserial.domain.error.BadRequestException;
 import com.example.newserial.domain.member.repository.Member;
 import com.example.newserial.domain.member.service.AuthDataService;
-import com.example.newserial.domain.news.service.NewsService;
 import com.example.newserial.domain.quiz.dto.NewsQuizAttemptRequestDto;
-import com.example.newserial.domain.quiz.dto.NewsQuizAttemptResponseDto;
 import com.example.newserial.domain.quiz.dto.OxQuizAttemptRequestDto;
 import com.example.newserial.domain.quiz.service.QuizService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class QuizController {
@@ -58,7 +53,7 @@ public class QuizController {
     public ResponseEntity<?> getOXQuiz(HttpServletRequest request){
         try {
             Member member = authDataService.checkAccessToken(request);
-            return quizService.getOXQuiz(member);
+            return ResponseEntity.ok(quizService.getOXQuiz(member));
         } catch (BadRequestException e) {    //액세스 토큰, 리프레시 토큰 모두 만료된 경우
             return authDataService.redirectToLogin();
         } catch (JsonProcessingException e) {

--- a/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuizAttemptRepository.java
+++ b/NewSerial/src/main/java/com/example/newserial/domain/quiz/repository/OxQuizAttemptRepository.java
@@ -12,4 +12,5 @@ public interface OxQuizAttemptRepository extends JpaRepository<OxQuizAttempt, Ox
     boolean existsByMember(Member member);
     List<OxQuizAttempt> findByMember(Member member);
     Optional<OxQuizAttempt> findByMemberAndWords(Member member, Words words);
+    boolean existsByMemberAndWords(Member member, Words words);
 }


### PR DESCRIPTION
한입퀴즈 반환 시 리스트에 5개씩 담아 리스트를 반환하는 형태로 수정.
사용자가 퀴즈를 풀었는지 아닌지에 따라 다른 내용을 담음.
회원가입 시 초기 펫 상태를 가진 펫 엔티티를 pet db에 저장.